### PR TITLE
Fix: Add ArgumentError for incompatible RegularizedBoseKernel with Fermionic statistics

### DIFF
--- a/src/lib/basis.jl
+++ b/src/lib/basis.jl
@@ -10,6 +10,11 @@ mutable struct FiniteTempBasis{S, K} <: AbstractBasis{S}
     v::PiecewiseLegendrePolyVector
     uhat::PiecewiseLegendreFTVector
 	function FiniteTempBasis{S}(kernel::K, sve_result::SVEResult{K}, β::Real, ωmax::Real, ε::Real) where {S<:Statistics, K<:AbstractKernel}
+	    # Validate kernel/statistics compatibility
+	    if isa(kernel, RegularizedBoseKernel) && S === Fermionic
+	        throw(ArgumentError("RegularizedBoseKernel is incompatible with Fermionic statistics"))
+	    end
+	    
 	    # Create basis
 	    status = Ref{Int32}(-100)
 	    basis = LibSparseIR.spir_basis_new(_statistics_to_c(S), β, ωmax, kernel.ptr, sve_result.ptr, status)

--- a/test/lib/basis_tests.jl
+++ b/test/lib/basis_tests.jl
@@ -18,7 +18,7 @@
 
 	@testset "FiniteTempBasis{S} for K=RegularizedBoseKernel" begin
 		kernel = RegularizedBoseKernel(10.0)
-		@test_throws "Failed to create FiniteTempBasis" FiniteTempBasis(Fermionic(), β, ωmax, ε; kernel)
+		@test_throws ArgumentError("RegularizedBoseKernel is incompatible with Fermionic statistics") FiniteTempBasis(Fermionic(), β, ωmax, ε; kernel)
 
 		kernel = RegularizedBoseKernel(10.0)
 		basis = FiniteTempBasis(Bosonic(), β, ωmax, ε; kernel)


### PR DESCRIPTION
## Summary
- Resolves #21 by adding explicit validation for kernel/statistics compatibility
- Throws `ArgumentError` when `RegularizedBoseKernel` is used with `Fermionic` statistics
- Updates test to expect the specific `ArgumentError` instead of generic error

## Test plan
- [x] Verify `ArgumentError` is thrown for `Fermionic` + `RegularizedBoseKernel`
- [x] Verify `Bosonic` + `RegularizedBoseKernel` continues to work
- [x] Confirm error message is descriptive and helpful
- [x] Run existing test suite to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)